### PR TITLE
AMM-1002 : Preprod- Unable to separate a Customization field for

### DIFF
--- a/src/main/java/com/iemr/common/data/customization/SectionAndFieldsMapping.java
+++ b/src/main/java/com/iemr/common/data/customization/SectionAndFieldsMapping.java
@@ -11,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Entity
@@ -98,6 +100,8 @@ public class SectionAndFieldsMapping {
 	
 	@Column(name = "ProjectID")
 	@Expose
+	@NotNull(message="ProjectId is Required")
+	@Min(value=1, message = "ProjectId must be possitive")
 	private Integer projectId;
 	
 	@Transient

--- a/src/main/java/com/iemr/common/data/customization/SectionAndFieldsMapping.java
+++ b/src/main/java/com/iemr/common/data/customization/SectionAndFieldsMapping.java
@@ -96,6 +96,10 @@ public class SectionAndFieldsMapping {
 	@Column(name = "FieldTitle")
 	private String fieldTitle;
 	
+	@Column(name = "ProjectID")
+	@Expose
+	private Integer projectId;
+	
 	@Transient
 	private String[] options;
 

--- a/src/main/java/com/iemr/common/data/customization/SectionFieldsMappingDTO.java
+++ b/src/main/java/com/iemr/common/data/customization/SectionFieldsMappingDTO.java
@@ -14,6 +14,7 @@ public class SectionFieldsMappingDTO {
 	private String sectionName;
 	private String createdBy;
 	private Integer serviceProviderId;
+	private Integer projectId;
 	private List<SectionAndFieldsMapping> fields;
 
 }

--- a/src/main/java/com/iemr/common/repo/customization/SectionAndFieldsMappingRepo.java
+++ b/src/main/java/com/iemr/common/repo/customization/SectionAndFieldsMappingRepo.java
@@ -16,7 +16,8 @@ public interface SectionAndFieldsMappingRepo extends CrudRepository<SectionAndFi
 //	List<SectionAndFieldsMapping> findBySectionIdAndSectionNameAndServiceProviderId(
 //			@Param("sectionId") Integer sectionId, @Param("serviceProviderId") Integer serviceProviderId);
 
-	@Query("SELECT sfm FROM SectionAndFieldsMapping sfm WHERE sfm.sectionId = :sectionId AND (sfm.serviceProviderId = :serviceProviderId OR sfm.serviceProviderId= 0) AND (sfm.projectId = :projectId OR sfm.projectId= 0)")
+
+	@Query("SELECT sfm FROM SectionAndFieldsMapping sfm WHERE sfm.fieldName = :fieldName AND (sfm.serviceProviderId = :serviceProviderId OR sfm.serviceProviderId = 0) AND (sfm.projectId = :projectId OR sfm.projectId = 0)")
 	List<SectionAndFieldsMapping> findSectionIdAndSectionNameAndServiceProviderId(
 			@Param("sectionId") Integer sectionId, @Param("serviceProviderId") Integer serviceProviderId, @Param("projectId") Integer projectId);
 	

--- a/src/main/java/com/iemr/common/repo/customization/SectionAndFieldsMappingRepo.java
+++ b/src/main/java/com/iemr/common/repo/customization/SectionAndFieldsMappingRepo.java
@@ -16,14 +16,14 @@ public interface SectionAndFieldsMappingRepo extends CrudRepository<SectionAndFi
 //	List<SectionAndFieldsMapping> findBySectionIdAndSectionNameAndServiceProviderId(
 //			@Param("sectionId") Integer sectionId, @Param("serviceProviderId") Integer serviceProviderId);
 
-	@Query("SELECT sfm FROM SectionAndFieldsMapping sfm WHERE sfm.sectionId = :sectionId AND (sfm.serviceProviderId = :serviceProviderId OR sfm.serviceProviderId= 0)")
+	@Query("SELECT sfm FROM SectionAndFieldsMapping sfm WHERE sfm.sectionId = :sectionId AND (sfm.serviceProviderId = :serviceProviderId OR sfm.serviceProviderId= 0) AND (sfm.projectId = :projectId OR sfm.projectId= 0)")
 	List<SectionAndFieldsMapping> findSectionIdAndSectionNameAndServiceProviderId(
-			@Param("sectionId") Integer sectionId, @Param("serviceProviderId") Integer serviceProviderId);
+			@Param("sectionId") Integer sectionId, @Param("serviceProviderId") Integer serviceProviderId, @Param("projectId") Integer projectId);
 	
 	@Query("SELECT sfm FROM SectionAndFieldsMapping sfm WHERE sfm.id = :id")
 	SectionAndFieldsMapping getById(@Param("id") Integer id);
 
-	@Query("SELECT sfm FROM SectionAndFieldsMapping sfm WHERE sfm.fieldName = :fieldName and sfm.serviceProviderId = :serviceProviderId")
-	List<SectionAndFieldsMapping> getByFieldName(@Param("fieldName") String fieldName,@Param("serviceProviderId") Integer serviceProviderId);
+	@Query("SELECT sfm FROM SectionAndFieldsMapping sfm WHERE sfm.fieldName = :fieldName and sfm.serviceProviderId = :serviceProviderId and sfm.projectId = :projectId")
+	List<SectionAndFieldsMapping> getByFieldName(@Param("fieldName") String fieldName,@Param("serviceProviderId") Integer serviceProviderId,@Param("projectId") Integer projectId);
 	
 }

--- a/src/main/java/com/iemr/common/service/customization/CustomizationServiceImpl.java
+++ b/src/main/java/com/iemr/common/service/customization/CustomizationServiceImpl.java
@@ -180,14 +180,15 @@ public class CustomizationServiceImpl implements CustomizationService {
 		try {
 
 			if (sectionFieldsMappingDTO != null && sectionFieldsMappingDTO.getFields() != null
-					&& sectionFieldsMappingDTO.getFields().size() > 0) {
+					&& sectionFieldsMappingDTO.getFields().size() > 0 && sectionFieldsMappingDTO.getProjectId() != null) {
 				SectionAndFieldsMapping sectionAndFieldsMapping;
 				List<SectionAndFieldsMapping> sectionAndFieldsMappingList = new ArrayList<>();
 				for (SectionAndFieldsMapping sectionFieldsMapping : sectionFieldsMappingDTO.getFields()) {
 					List<SectionAndFieldsMapping> byFieldName = sectionAndFieldsMappingRepo
-							.getByFieldName(sectionFieldsMapping.getFieldName(),sectionFieldsMapping.getServiceProviderId());
+							.getByFieldName(sectionFieldsMapping.getFieldName(),sectionFieldsMapping.getServiceProviderId(),sectionFieldsMappingDTO.getProjectId());
 					sectionAndFieldsMapping = new SectionAndFieldsMapping();
 					sectionAndFieldsMapping.setSectionId(sectionFieldsMappingDTO.getSectionId());
+					sectionAndFieldsMapping.setProjectId(sectionFieldsMappingDTO.getProjectId());
 					sectionAndFieldsMapping.setCreatedBy(sectionFieldsMappingDTO.getCreatedBy());
 					sectionAndFieldsMapping.setAllowMax(sectionFieldsMapping.getAllowMax());
 					sectionAndFieldsMapping.setFieldName(sectionFieldsMapping.getFieldName());
@@ -286,14 +287,14 @@ public class CustomizationServiceImpl implements CustomizationService {
 		try {
 			List<SectionAndFieldsMapping> resultSet = sectionAndFieldsMappingRepo
 					.findSectionIdAndSectionNameAndServiceProviderId(sectionAndFieldsMapping.getSectionId(),
-							sectionAndFieldsMapping.getServiceProviderId());
+							sectionAndFieldsMapping.getServiceProviderId(), sectionAndFieldsMapping.getProjectId());
 
 			String sectionName = sectionMasterCustomizationRepo.findSectionName(sectionAndFieldsMapping.getSectionId());
 			Map<String, Object> responseMap = new HashMap<>();
 			responseMap.put("sectionId", sectionAndFieldsMapping.getSectionId());
 			responseMap.put("sectionName", sectionName);
 			responseMap.put("serviceProviderId", sectionAndFieldsMapping.getServiceProviderId());
-
+			responseMap.put("projectId", sectionAndFieldsMapping.getProjectId());
 			List<Map<String, Object>> fieldsList = new ArrayList<>();
 			for (SectionAndFieldsMapping field : resultSet) {
 				Map<String, Object> fieldMap = new HashMap<>();
@@ -372,6 +373,8 @@ public class CustomizationServiceImpl implements CustomizationService {
 			if (sectionAndFieldsMapping.getId() != null) {
 				SectionAndFieldsMapping response = sectionAndFieldsMappingRepo.getById(sectionAndFieldsMapping.getId());
 				if (response != null) {
+					if(sectionAndFieldsMapping.getProjectId() != null)
+						response.setProjectId(sectionAndFieldsMapping.getProjectId());
 					if (sectionAndFieldsMapping.getFieldName() != null)
 						response.setFieldName(sectionAndFieldsMapping.getFieldName());
 					if (sectionAndFieldsMapping.getIsRequired() != null)

--- a/src/main/java/com/iemr/common/service/customization/CustomizationServiceImpl.java
+++ b/src/main/java/com/iemr/common/service/customization/CustomizationServiceImpl.java
@@ -285,6 +285,9 @@ public class CustomizationServiceImpl implements CustomizationService {
 		SectionAndFieldsMapping sectionAndFieldsMapping = InputMapper.gson().fromJson(request,
 				SectionAndFieldsMapping.class);
 		try {
+			if(sectionAndFieldsMapping.getProjectId() == null) {
+				throw new IllegalArgumentException("ProjectId is required");
+			}
 			List<SectionAndFieldsMapping> resultSet = sectionAndFieldsMappingRepo
 					.findSectionIdAndSectionNameAndServiceProviderId(sectionAndFieldsMapping.getSectionId(),
 							sectionAndFieldsMapping.getServiceProviderId(), sectionAndFieldsMapping.getProjectId());
@@ -373,8 +376,11 @@ public class CustomizationServiceImpl implements CustomizationService {
 			if (sectionAndFieldsMapping.getId() != null) {
 				SectionAndFieldsMapping response = sectionAndFieldsMappingRepo.getById(sectionAndFieldsMapping.getId());
 				if (response != null) {
-					if(sectionAndFieldsMapping.getProjectId() != null)
+					if(sectionAndFieldsMapping.getProjectId() != null) {
+						ProjectCustomization project = projectCustomizationRepo.findById(sectionAndFieldsMapping.getProjectId())
+								.orElseThrow(() -> new IllegalArgumentException("Invalid projectId"));
 						response.setProjectId(sectionAndFieldsMapping.getProjectId());
+					}
 					if (sectionAndFieldsMapping.getFieldName() != null)
 						response.setFieldName(sectionAndFieldsMapping.getFieldName());
 					if (sectionAndFieldsMapping.getIsRequired() != null)


### PR DESCRIPTION
different-2 service line in single provider

## 📋 Description

JIRA ID: AMM-1002

Preprod- Unable to separate a Customization field for different 2 service line in single provider

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `projectId` field to enhance data mapping for sections and fields.
	- Updated methods to filter and handle data based on `projectId`, improving specificity in operations related to project and section mappings.

- **Bug Fixes**
	- Implemented checks to ensure `projectId` is provided when saving section and field mappings, enhancing data integrity.
	- Added validation for `projectId` in data retrieval processes to prevent errors.

- **Documentation**
	- Updated response formats to include `projectId` for clearer context in returned data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->