### PR TITLE
Fix column name mismatch in StockAlertData class and v_emailstockalert table

### DIFF
--- a/src/main/java/com/iemr/common/data/email/StockAlertData.java
+++ b/src/main/java/com/iemr/common/data/email/StockAlertData.java
@@ -77,7 +77,7 @@ public class StockAlertData {
 	@Expose
 	private String districtName;
 	
-	@Column(name = "QuantityinhandPercent")
+	@Column(name = "QuantityConsumedPercent")
 	@Expose
 	private Double quantityinhandPercent;
 }


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

The column name in the StockAlertData class does not match the corresponding column in the v_emailstockalert table, causing an error during execution. This PR resolves the issue by aligning the column names correctly.
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
---

