### PR TITLE
Fix the Service ID Fetching issue

### DIFF
--- a/src/main/java/com/iemr/common/controller/users/IEMRAdminController.java
+++ b/src/main/java/com/iemr/common/controller/users/IEMRAdminController.java
@@ -369,7 +369,7 @@ public class IEMRAdminController {
 							m_UserServiceRoleMapping.getM_ProviderServiceMapping().getM_ServiceMaster().toString()));
 					previlegeObj.getJSONObject(serv).put("serviceName", serv);
 					previlegeObj.getJSONObject(serv).put("serviceID",
-							m_UserServiceRoleMapping.getM_ProviderServiceMapping().getProviderServiceMapID());
+							m_UserServiceRoleMapping.getM_ProviderServiceMapping().getM_ServiceMaster().getServiceID());
 					previlegeObj.getJSONObject(serv).put("providerServiceMapID",
 							m_UserServiceRoleMapping.getM_ProviderServiceMapping().getProviderServiceMapID());
 					previlegeObj.getJSONObject(serv).put("apimanClientKey",


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

AMM-1626

The Service ID was not mapped correctly. Initially, it was mapped using ProviderServiceMapID, and this value was being passed in the payload for the next API. This caused the issue. It has now been updated to use the correct ServiceID.
---

## ✅ Type of Change

- [X] 🐞 **Bug fix** (non-breaking change which resolves an issue)


---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the assignment of the service identifier in user mapping to ensure accurate service information is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->