### PR TITLE
Production_ASSAM_Session timeout issue

### DIFF
--- a/src/main/java/com/iemr/common/data/userbeneficiarydata/Language.java
+++ b/src/main/java/com/iemr/common/data/userbeneficiarydata/Language.java
@@ -56,7 +56,6 @@ public class Language
 	private Set<BenDemographics> i_bendemographics;
 
 	@OneToMany(fetch = FetchType.LAZY, mappedBy = "m_language")
-	@Transient
 	private Set<UserLangMapping> m_UserLangMappings;
 
 	@OneToMany(fetch = FetchType.LAZY, mappedBy = "language")

--- a/src/main/java/com/iemr/common/data/users/User.java
+++ b/src/main/java/com/iemr/common/data/users/User.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.Expose;
 import com.iemr.common.data.callhandling.OutboundCallRequest;
 import com.iemr.common.data.feedback.FeedbackDetails;
@@ -76,7 +77,7 @@ public class User implements Serializable  {
 
 	@Expose
 	// @Transient
-	@OneToMany(/* mappedBy = "m_user", fetch = FetchType.EAGER */)
+	@OneToMany(fetch = FetchType.EAGER)
 	@JoinColumn(updatable = false, insertable = false, name = "userID", referencedColumnName = "userID")
 	private Set<UserLangMapping> m_UserLangMappings;
 
@@ -134,12 +135,15 @@ public class User implements Serializable  {
 	@Column(name = "AadhaarNo")
 	private String aadhaarNo;
 	@Expose
+	@JsonProperty("pan")
 	@Column(name = "PAN")
 	private String pAN;
 	@Expose
+	@JsonProperty("dob")
 	@Column(name = "DOB")
 	private Timestamp dOB;
 	@Expose
+	@JsonProperty("doj")
 	@Column(name = "DOJ")
 	private Timestamp dOJ;
 	@Expose


### PR DESCRIPTION
## 📋 Description

JIRA ID: AMM-1670

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.

Issue:
When the Redis session expires after 30 minutes, the system attempts to fetch the user details from the database. However, due to issues like incorrect field mappings (e.g., pan), lazy loading failures (m_UserLangMappings), and missing Redis refresh logic, the user object is not returned properly—resulting in incomplete or failed API responses.

Logs :
<img width="1839" height="167" alt="Screenshot from 2025-07-31 19-33-49" src="https://github.com/user-attachments/assets/9b401cfd-5c5e-4c9e-953e-a5026d474532" />

**Fixes and Corrective Actions**
**1. Serialization Fixes (PAN, DOB, DOJ fields)**
Issue: JSON serialization failed because field names didn’t match — e.g., "pan" in JSON vs pAN in Java class.

**Fix:**
Added @JsonProperty("pan"), @JsonProperty("dob"), and @JsonProperty("doj") to correctly map JSON fields during deserialization.

**2. Lazy Loading Fixes (m_UserLangMappings)**
Issue: @OneToMany(fetch = FetchType.LAZY) mapping caused deserialization errors when Redis tried to deserialize outside an active Hibernate session:

could not initialize proxy - no Session

**Fix:**
Changed fetch type to EAGER to ensure complete serialization.

Refer:https://pmp.piramalswasthya.org/confluence/spaces/AMRIT/pages/96043113/AMM-1670+Production_ASSAM_Session+timeout+issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User information now includes "pan", "dob", and "doj" fields in API responses.

* **Improvements**
  * Enhanced language mapping persistence for user and language data.
  * Updated project version to 3.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->