### PR TITLE
add swagger json automate

### DIFF
--- a/.github/workflows/swagger-export.yml
+++ b/.github/workflows/swagger-export.yml
@@ -1,0 +1,98 @@
+name: Export Swagger
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  swagger:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout Common-API (current repo)
+      - uses: actions/checkout@v4
+
+      # Setup Java
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      # Build WAR
+      - name: Build Common-API
+        run: mvn clean package -DskipTests
+
+      # Run application with swagger profile
+      - name: Run application
+        run: |
+          WAR_FILE=$(find target -name "*.war" | grep -v original | head -1)
+          if [ -z "$WAR_FILE" ]; then
+            echo "WAR file not found"
+            exit 1
+          fi
+
+          echo "Starting app using $WAR_FILE"
+          java -jar "$WAR_FILE" --spring.profiles.active=swagger > /tmp/app.log 2>&1 &
+          echo $! > /tmp/app.pid
+
+      # Wait for Swagger to be available
+      - name: Wait for Swagger endpoint
+        run: |
+          for i in {1..40}; do
+            if curl -sf http://localhost:8083/v3/api-docs > /dev/null; then
+              echo "Swagger is available"
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Application failed to start"
+          cat /tmp/app.log
+          exit 1
+
+      # Fetch Swagger JSON
+      - name: Fetch Swagger JSON
+        run: |
+          curl http://localhost:8083/v3/api-docs -o common-api.json
+          test -s common-api.json
+
+      # Clone AMRIT-Docs
+      - name: Clone AMRIT-Docs
+        run: |
+          git clone --depth 1 https://github.com/PSMRI/AMRIT-Docs.git amrit-docs
+
+      # Copy Swagger
+      - name: Copy Swagger JSON
+        run: |
+          mkdir -p amrit-docs/docs/swagger
+          cp common-api.json amrit-docs/docs/swagger/common-api.json
+
+      # Commit & push only if changed
+      - name: Commit and push
+        run: |
+          cd amrit-docs
+
+          if git diff --quiet docs/swagger/common-api.json; then
+            echo "No Swagger changes"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add docs/swagger/common-api.json
+          git commit -m "chore: update Common-API Swagger [skip ci]" \
+                     -m "Source: ${{ github.repository }}@${{ github.sha }}"
+
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/PSMRI/AMRIT-Docs.git HEAD:main
+
+      # Stop app
+      - name: Stop application
+        if: always()
+        run: |
+          if [ -f /tmp/app.pid ]; then
+            kill $(cat /tmp/app.pid) || true
+          fi

--- a/.github/workflows/swagger-export.yml
+++ b/.github/workflows/swagger-export.yml
@@ -75,9 +75,20 @@ jobs:
         run: |
           cd amrit-docs
 
-          if git diff --quiet docs/swagger/common-api.json; then
-            echo "No Swagger changes"
-            exit 0
+          # Check if file is tracked and detect changes
+          if git ls-files --error-unmatch docs/swagger/common-api.json > /dev/null 2>&1; then
+            # File is tracked, check for changes
+            if git diff --quiet docs/swagger/common-api.json; then
+              echo "No Swagger changes"
+              exit 0
+            fi
+          else
+            # File is untracked, stage it and check if there are staged changes
+            git add docs/swagger/common-api.json
+            if git diff --staged --quiet docs/swagger/common-api.json; then
+              echo "No Swagger changes"
+              exit 0
+            fi
           fi
 
           git config user.name "github-actions[bot]"
@@ -87,7 +98,7 @@ jobs:
           git commit -m "chore: update Common-API Swagger [skip ci]" \
                      -m "Source: ${{ github.repository }}@${{ github.sha }}"
 
-          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/PSMRI/AMRIT-Docs.git HEAD:main
+          git push https://x-access-token:${{ secrets.AMRIT_DOCS_PAT }}@github.com/PSMRI/AMRIT-Docs.git HEAD:main
 
       # Stop app
       - name: Stop application

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -40,3 +40,7 @@ logging:
 # CORS configuration for Swagger profile
 cors:
   allowed-origins: http://localhost:*
+
+# JWT configuration for Swagger profile
+jwt:
+  secret: test-secret-key-for-swagger-profile-only

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -36,3 +36,7 @@ springdoc:
 logging:
   level:
     root: INFO
+
+# CORS configuration for Swagger profile
+cors:
+  allowed-origins: http://localhost:*

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -1,0 +1,39 @@
+server:
+  port: 8083
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:swaggerdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+
+  flyway:
+    enabled: false
+
+  liquibase:
+    enabled: false
+
+  session:
+    store-type: none
+
+  task:
+    scheduling:
+      enabled: false
+
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: false
+
+logging:
+  level:
+    root: INFO

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -9,7 +9,6 @@ spring:
     password: ""
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: none
     show-sql: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to export API documentation, wait for the docs endpoint, fetch the OpenAPI JSON, and synchronize it to the central documentation repo (commits only when changes are detected; includes robust cleanup and error handling).
  * Added a dedicated runtime profile for generating docs in isolation using an in-memory datastore and disabled migrations so the API docs endpoint can be reliably exported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->