### PR TITLE
Add failed login attempt tracking and basic lock after 5 attempts

### DIFF
--- a/src/main/java/com/iemr/common/data/users/User.java
+++ b/src/main/java/com/iemr/common/data/users/User.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
+import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -82,7 +83,7 @@ public class User implements Serializable  {
 	@JoinColumn(updatable = false, insertable = false, name = "userID", referencedColumnName = "userID")
 	private Set<UserLangMapping> m_UserLangMappings;
 
-	@OneToMany(mappedBy = "mUser", fetch = FetchType.EAGER)
+	@OneToMany(mappedBy = "m_User", fetch = FetchType.EAGER)
 	@Transient
 	@Expose
 	private Set<FeedbackDetails> feedbackDetails;
@@ -208,6 +209,10 @@ public class User implements Serializable  {
 	@Expose
 	@Column(name = "failed_attempt")
 	private Integer failedAttempt;
+
+	/* @Expose
+	@Column(name="lock_until")
+	private LocalDateTime lockUntil; */
 
 	@Expose
 	@Column(name = "dhistoken")

--- a/src/main/java/com/iemr/common/service/users/IEMRAdminUserServiceImpl.java
+++ b/src/main/java/com/iemr/common/service/users/IEMRAdminUserServiceImpl.java
@@ -386,29 +386,62 @@ public class IEMRAdminUserServiceImpl implements IEMRAdminUserService {
 		return users.get(0);
 	}
 
+
 	@Override
-	public LoginResponseModel userAuthenticateV1(LoginRequestModel loginRequest, String ipAddress, String hostName)
-			throws Exception {
+
+
+	public LoginResponseModel userAuthenticateV1(LoginRequestModel loginRequest,
+												 String ipAddress, String hostName) throws Exception {
+
 		LoginResponseModel loginResponseModel = null;
-		List<User> users = iEMRUserRepositoryCustom.findByUserName(loginRequest.getUserName());
+
+		List<User> users = iEMRUserRepositoryCustom
+				.findByUserName(loginRequest.getUserName());
+
 		if (users.size() == 1) {
-			User user = users.get(0);
+
+			User user = users.get(0);   // ✅ FIRST declare user
+
+			// ✅ THEN check failed attempts
+			Integer failedAttempt = user.getFailedAttempt();
+
+			if (failedAttempt != null && failedAttempt >= 5) {
+				throw new IEMRException(
+						"Your account has been locked. You can try tomorrow or connect to the administrator."
+				);
+			}
+
 			try {
-				if (!securePassword.validatePasswordExisting(loginRequest.getPassword(), user.getPassword())) {
+				if (!securePassword.validatePasswordExisting(
+						loginRequest.getPassword(),
+						user.getPassword())) {
+
+					int currentAttempt =
+							user.getFailedAttempt() == null ? 0 : user.getFailedAttempt();
+
+					currentAttempt++;
+					user.setFailedAttempt(currentAttempt);
+					iEMRUserRepositoryCustom.save(user);
+
 					throw new IEMRException("Invalid username or password");
 				}
+
 			} catch (Exception e) {
 				throw new IEMRException("Invalid username or password");
 			}
-			loginResponseModel = userMapper.userDataToLoginResponse(user);
-			logger.info("Login response is " + loginResponseModel.toString());
-			List<UserServiceRoleMapping> userServiceRoleMappings = getUserServiceRoleMapping(
-					loginResponseModel.getUserID());
-			loginResponseModel
-					.setUserServiceRoleMappings(userServiceRoleMapper.userRoleToLoginUserRole(userServiceRoleMappings));
 
-			// loginResponseModel.setHostName(hostName);
-			// loginResponseModel.setIpAddress(ipAddress);
+			// ✅ reset on success
+			user.setFailedAttempt(0);
+			iEMRUserRepositoryCustom.save(user);
+
+			loginResponseModel = userMapper.userDataToLoginResponse(user);
+
+			List<UserServiceRoleMapping> userServiceRoleMappings =
+					getUserServiceRoleMapping(loginResponseModel.getUserID());
+
+			loginResponseModel.setUserServiceRoleMappings(
+					userServiceRoleMapper.userRoleToLoginUserRole(userServiceRoleMappings));
+
 		} else {
 			throw new IEMRException("Invalid username or password");
 		}


### PR DESCRIPTION
## 📋 Description

JIRA ID: N/A

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [✅ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Testing

Verified compilation using:

mvn clean install -DskipTests

Manually tested login scenarios:

Wrong password increments failed attempt.

After 5 consecutive failures, login is blocked.

Successful login resets failed attempt counter.

No changes were made to existing test cases..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account locking mechanism that activates after multiple consecutive failed login attempts to enhance security.

* **Bug Fixes**
  * Improved user authentication system with enhanced password validation and error handling.
  * Refined service role mapping integration in login responses for better access control clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->