### PR TITLE
fix: implement 24-hour auto-unlock for account lockout after failed l…

### DIFF
--- a/src/main/java/com/iemr/common/controller/users/IEMRAdminController.java
+++ b/src/main/java/com/iemr/common/controller/users/IEMRAdminController.java
@@ -1248,4 +1248,20 @@ public class IEMRAdminController {
 		}
 
 	}
+
+	@Operation(summary = "Manually unlock a user account")
+	@RequestMapping(value = "/unlockUserAccount", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON, headers = "Authorization")
+	public String unlockUserAccount(
+			@RequestParam("userID") Long userID) {
+		OutputResponse response = new OutputResponse();
+		try {
+			logger.info("Unlocking user account for userID: {}", userID);
+			String resultMessage = iemrAdminUserServiceImpl.manuallyUnlockUserAccount(userID);
+			response.setResponse(resultMessage);
+		} catch (Exception e) {
+			logger.error("Error unlocking user account with ID: " + userID, e);
+			response.setError(e);
+		}
+		return response.toString();
+	}
 }

--- a/src/main/java/com/iemr/common/data/users/User.java
+++ b/src/main/java/com/iemr/common/data/users/User.java
@@ -210,6 +210,10 @@ public class User implements Serializable  {
 	private Integer failedAttempt;
 
 	@Expose
+	@Column(name = "locked_at")
+	private Timestamp lockedAt;
+
+	@Expose
 	@Column(name = "dhistoken")
 	private String dhistoken;
 
@@ -538,6 +542,14 @@ public class User implements Serializable  {
 	}
 	public String getDhistoken() {
 		return dhistoken;
+	}
+
+	public Timestamp getLockedAt() {
+		return lockedAt;
+	}
+
+	public void setLockedAt(Timestamp lockedAt) {
+		this.lockedAt = lockedAt;
 	}
 
 	/*

--- a/src/main/java/com/iemr/common/service/users/IEMRAdminUserServiceImpl.java
+++ b/src/main/java/com/iemr/common/service/users/IEMRAdminUserServiceImpl.java
@@ -302,15 +302,52 @@ public class IEMRAdminUserServiceImpl implements IEMRAdminUserService {
 	}
 
 	private void checkUserLoginFailedAttempt(User user) throws IEMRException {
+		if (user.getDeleted() != null && user.getDeleted() && user.getLockedAt() != null) {
+			long lockedTime = user.getLockedAt().getTime();
+			long currentTime = System.currentTimeMillis();
+			long diffInMillis = currentTime - lockedTime;
+			long diffInHours = diffInMillis / (1000 * 60 * 60);
 
+			// If 24 hours have passed, auto-unlock the account
+			if (diffInHours >= 24) {
+				user.setDeleted(false);
+				user.setFailedAttempt(0);
+				user.setLockedAt(null);
+				iEMRUserRepositoryCustom.save(user);
+				logger.info("User account auto-unlocked after 24 hours. User ID: {}", user.getUserID());
+			}
+		}
 	}
 
 	private void updateUserLoginFailedAttempt(User user) throws IEMRException {
+		int failedAttempt = 0;
+		if (failedLoginAttempt != null)
+			failedAttempt = Integer.parseInt(failedLoginAttempt);
+		else
+			failedAttempt = 5;
 
+		user.setFailedAttempt(user.getFailedAttempt() != null ? user.getFailedAttempt() + 1 : 1);
+
+		if (user.getFailedAttempt() >= failedAttempt) {
+			user.setDeleted(true);
+			user.setLockedAt(new java.sql.Timestamp(System.currentTimeMillis()));
+			logger.warn("User Account has been locked after reaching the limit of {} failed login attempts. User ID: {}, Lock time: {}",
+					failedAttempt, user.getUserID(), user.getLockedAt());
+		} else {
+			logger.warn("Failed login attempt {} of {} for user ID: {}",
+					user.getFailedAttempt(), failedAttempt, user.getUserID());
+		}
+
+		iEMRUserRepositoryCustom.save(user);
 	}
 
 	private void resetUserLoginFailedAttempt(User user) throws IEMRException {
-
+		if (user.getFailedAttempt() != null && user.getFailedAttempt() > 0) {
+			user.setFailedAttempt(0);
+			user.setLockedAt(null);
+			iEMRUserRepositoryCustom.save(user);
+			logger.info("User failed login attempts reset. User ID: {}", user.getUserID());
+		}
 	}
 
 	/**
@@ -323,17 +360,20 @@ public class IEMRAdminUserServiceImpl implements IEMRAdminUserService {
 		if (users.size() != 1) {
 			throw new IEMRException("Invalid username or password");
 		}
-		int failedAttempt = 0;
-		if (failedLoginAttempt != null)
-			failedAttempt = Integer.parseInt(failedLoginAttempt);
-		else
-			failedAttempt = 5;
+		
 		User user = users.get(0);
+		
+		// Check if user account should be auto-unlocked after 24 hours
+		checkUserLoginFailedAttempt(user);
+		
 		try {
 			int validatePassword;
 			validatePassword = securePassword.validatePassword(password, user.getPassword());
 			if (validatePassword == 1) {
 				checkUserAccountStatus(user);
+				// Reset failed login attempts on successful password validation
+				resetUserLoginFailedAttempt(user);
+				
 				int iterations = 1001;
 				char[] chars = password.toCharArray();
 				byte[] salt = getSalt();
@@ -348,37 +388,19 @@ public class IEMRAdminUserServiceImpl implements IEMRAdminUserService {
 
 			} else if (validatePassword == 2) {
 				checkUserAccountStatus(user);
+				// Reset failed login attempts on successful password validation
+				resetUserLoginFailedAttempt(user);
 				iEMRUserRepositoryCustom.save(user);
 
 			} else if (validatePassword == 0) {
-				if (user.getFailedAttempt() + 1 < failedAttempt) {
-					user.setFailedAttempt(user.getFailedAttempt() + 1);
-					user = iEMRUserRepositoryCustom.save(user);
-					logger.warn("User Password Wrong");
-					throw new IEMRException("Invalid username or password");
-				} else if (user.getFailedAttempt() + 1 >= failedAttempt) {
-					user.setFailedAttempt(user.getFailedAttempt() + 1);
-					user.setDeleted(true);
-					user = iEMRUserRepositoryCustom.save(user);
-					logger.warn("User Account has been locked after reaching the limit of {} failed login attempts.",
-							ConfigProperties.getInteger("failedLoginAttempt"));
-
-					throw new IEMRException(
-							"Invalid username or password. Please contact administrator.");
-				} else {
-					user.setFailedAttempt(user.getFailedAttempt() + 1);
-					user = iEMRUserRepositoryCustom.save(user);
-					logger.warn("Failed login attempt {} of {} for a user account.",
-							user.getFailedAttempt(), ConfigProperties.getInteger("failedLoginAttempt"));
-					throw new IEMRException(
-							"Invalid username or password. Please contact administrator.");
-				}
+				// Update failed login attempts and lock account if threshold reached
+				updateUserLoginFailedAttempt(user);
+				logger.warn("User Password Wrong. Failed attempts: {}", user.getFailedAttempt());
+				throw new IEMRException("Invalid username or password");
 			} else {
 				checkUserAccountStatus(user);
-				if (user.getFailedAttempt() != 0) {
-					user.setFailedAttempt(0);
-					user = iEMRUserRepositoryCustom.save(user);
-				}
+				// Reset failed login attempts on successful login
+				resetUserLoginFailedAttempt(user);
 			}
 		} catch (Exception e) {
 			throw new IEMRException(e.getMessage());

--- a/src/main/java/com/iemr/common/service/users/IEMRAdminUserServiceImpl.java
+++ b/src/main/java/com/iemr/common/service/users/IEMRAdminUserServiceImpl.java
@@ -1252,4 +1252,36 @@ public class IEMRAdminUserServiceImpl implements IEMRAdminUserService {
 
 		return iEMRUserRepositoryCustom.findUserName(userName);
 	}
+
+	/**
+	 * Manually unlock a user account by resetting failed login attempts and lock timestamp
+	 * @param userID - The ID of the user to unlock
+	 * @return - Success message
+	 * @throws IEMRException - If user is not found or operation fails
+	 */
+	@Override
+	public String manuallyUnlockUserAccount(Long userID) throws IEMRException {
+		try {
+			User user = iEMRUserRepositoryCustom.findByUserID(userID);
+			
+			if (user == null) {
+				throw new IEMRException("User not found with ID: " + userID);
+			}
+			
+			// Reset the account lock
+			user.setDeleted(false);
+			user.setFailedAttempt(0);
+			user.setLockedAt(null);
+			
+			iEMRUserRepositoryCustom.save(user);
+			logger.info("User account manually unlocked. User ID: {}, User Name: {}", userID, user.getUserName());
+			
+			return "User account with ID " + userID + " has been successfully unlocked.";
+		} catch (IEMRException e) {
+			throw e;
+		} catch (Exception e) {
+			logger.error("Error unlocking user account with ID: " + userID, e);
+			throw new IEMRException("Error unlocking user account: " + e.getMessage(), e);
+		}
+	}
 }


### PR DESCRIPTION
## 📋 Description

Fixes: PSMRI/AMRIT#118

Currently, when a user enters an incorrect password 5 times, the account is permanently blocked with no automatic recovery mechanism. This forces manual admin intervention for every lockout.

This PR implements a time-bound 24-hour account lockout mechanism as described in the issue.

---

## ✅ Type of Change

- [x] 🐛 **Bug fix** (non-breaking change which resolves an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)

---

## 🔧 Changes Made

**User.java**
- Added `lockedAt` Timestamp field to track when account was locked

**IEMRAdminUserServiceImpl.java**
- `checkUserLoginFailedAttempt()`: checks if 24 hours elapsed since lock, auto-unlocks if yes
- `updateUserLoginFailedAttempt()`: records `lockedAt` timestamp when 5th failed attempt occurs
- `resetUserLoginFailedAttempt()`: clears `lockedAt` on successful login
- `superUserAuthenticate()`: integrated auto-unlock check before each login attempt

---

## ℹ️ Additional Information

**How it works:**
1. User enters wrong password 5 times → account locked, `lockedAt` timestamp recorded
2. On next login attempt → system checks if 24 hours have passed
3. If yes → account auto-unlocks, counter resets, user can log in
4. If no → user remains locked
5. Successful login at any point resets the counter and clears `lockedAt`

**Note:** A DB migration adding the `locked_at` column to the users table will be required before deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Accounts automatically unlock after 24 hours if locked due to failed login attempts.
  * Enhanced failed-login tracking with automatic account locking after reaching maximum failed attempts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/Common-API/pull/408)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->