### PR TITLE
Remove PII from JWT token for mobile logins

### DIFF
--- a/src/main/java/com/iemr/common/controller/users/IEMRAdminController.java
+++ b/src/main/java/com/iemr/common/controller/users/IEMRAdminController.java
@@ -193,7 +193,10 @@ public class IEMRAdminController {
 			String jwtToken = null;
 			String refreshToken = null;
 			if (mUser.size() == 1) {
-				jwtToken = jwtUtil.generateToken(m_User.getUserName(), mUser.get(0).getUserID().toString());
+				String userIdStr = mUser.get(0).getUserID().toString();
+				jwtToken = isMobile
+						? jwtUtil.generateSecureToken(userIdStr)
+						: jwtUtil.generateToken(m_User.getUserName(), userIdStr);
 
 				User user = new User(); // Assuming the Users class exists
 				user.setUserID(mUser.get(0).getUserID());
@@ -209,7 +212,7 @@ public class IEMRAdminController {
 				);
 
 				if (isMobile) {
-					refreshToken = jwtUtil.generateRefreshToken(m_User.getUserName(), user.getUserID().toString());
+					refreshToken = jwtUtil.generateSecureRefreshToken(user.getUserID().toString());
 					logger.debug("Refresh token generated successfully for user: {}", user.getUserName());
 					String jti = jwtUtil.getJtiFromToken(refreshToken);
 					redisTemplate.opsForValue().set(
@@ -555,7 +558,7 @@ public class IEMRAdminController {
 				);
 
 				if (isMobile) {
-					refreshToken = jwtUtil.generateRefreshToken(m_User.getUserName(), user.getUserID().toString());
+					refreshToken = jwtUtil.generateSecureRefreshToken(user.getUserID().toString());
 					logger.debug("Refresh token generated successfully for user: {}", user.getUserName());
 					String jti = jwtUtil.getJtiFromToken(refreshToken);
 					redisTemplate.opsForValue().set(

--- a/src/main/java/com/iemr/common/utils/JwtUtil.java
+++ b/src/main/java/com/iemr/common/utils/JwtUtil.java
@@ -46,6 +46,27 @@ public class JwtUtil {
         return buildToken(username, userId, "access", ACCESS_EXPIRATION_TIME);
     }
 
+    // Mobile login: token without PII in sub
+    public String generateSecureToken(String userId) {
+        return buildSecureToken(userId, "access", ACCESS_EXPIRATION_TIME);
+    }
+
+    public String generateSecureRefreshToken(String userId) {
+        return buildSecureToken(userId, "refresh", REFRESH_EXPIRATION_TIME);
+    }
+
+    private String buildSecureToken(String userId, String tokenType, long expiration) {
+        return Jwts.builder()
+                .subject(userId)
+                .claim("userId", userId)
+                .claim("token_type", tokenType)
+                .id(UUID.randomUUID().toString())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
     /**
      * Generate a refresh token.
      *


### PR DESCRIPTION
Add generateSecureToken/generateSecureRefreshToken methods that use userId as sub instead of username. Mobile logins (okhttp User-Agent) use the secure token — web logins remain unchanged for backward compatibility. Other services will be migrated one by one.

## 📋 Description

JIRA ID: [AMM-2152](https://support.piramalfoundation.org/jira/browse/AMM-2152)

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
