### PR TITLE
fix: prevent JWT cookie accumulation in outgoing HTTP headers

### DIFF
--- a/src/main/java/com/iemr/common/utils/http/HttpUtils.java
+++ b/src/main/java/com/iemr/common/utils/http/HttpUtils.java
@@ -77,8 +77,10 @@ public class HttpUtils {
 	}
 
 	public ResponseEntity<String> getV1(String uri) throws URISyntaxException, MalformedURLException {
-		RestTemplateUtil.getJwttokenFromHeaders(headers);
-		HttpEntity<String> requestEntity = new HttpEntity<String>("", headers);
+		HttpHeaders requestHeaders = new HttpHeaders();
+		requestHeaders.add("Content-Type", "application/json");
+		RestTemplateUtil.getJwttokenFromHeaders(requestHeaders);
+		HttpEntity<String> requestEntity = new HttpEntity<String>("", requestHeaders);
 		ResponseEntity<String> responseEntity = rest.exchange(uri, HttpMethod.GET, requestEntity, String.class);
 		return responseEntity;
 	}
@@ -104,8 +106,10 @@ public class HttpUtils {
 
 	public String post(String uri, String json) {
 		String body;
-		RestTemplateUtil.getJwttokenFromHeaders(headers);
-		HttpEntity<String> requestEntity = new HttpEntity<String>(json, headers);
+		HttpHeaders requestHeaders = new HttpHeaders();
+		requestHeaders.add("Content-Type", "application/json");
+		RestTemplateUtil.getJwttokenFromHeaders(requestHeaders);
+		HttpEntity<String> requestEntity = new HttpEntity<String>(json, requestHeaders);
 		ResponseEntity<String> responseEntity = rest.exchange(uri, HttpMethod.POST, requestEntity, String.class);
 		setStatus((HttpStatus) responseEntity.getStatusCode());
 		body = responseEntity.getBody();


### PR DESCRIPTION


## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)

---

## ℹ️ Additional Information

Shared HttpHeaders field in HttpUtils was mutated via add() on every request, causing Cookie header to grow unbounded across calls. CTI server rejected requests once the header exceeded its size limit. post() and getV1() now create fresh HttpHeaders per request, consistent with the existing get() pattern.
