### PR TITLE
fix: AMM-2343 on lock/Unlock the api was returning 500 error

### DIFF
--- a/src/main/java/com/iemr/common/utils/JwtUserIdValidationFilter.java
+++ b/src/main/java/com/iemr/common/utils/JwtUserIdValidationFilter.java
@@ -159,7 +159,7 @@ public class JwtUserIdValidationFilter implements Filter {
 				logger.info("Validating JWT token from cookie");
 				if (jwtAuthenticationUtil.validateUserIdAndJwtToken(jwtFromCookie)) {
 					AuthorizationHeaderRequestWrapper authorizationHeaderRequestWrapper = new AuthorizationHeaderRequestWrapper(
-							request, "");
+							request, authHeader != null ? authHeader : "");
 					filterChain.doFilter(authorizationHeaderRequestWrapper, servletResponse);
 					return;
 				}
@@ -167,7 +167,7 @@ public class JwtUserIdValidationFilter implements Filter {
 				logger.info("Validating JWT token from header");
 				if (jwtAuthenticationUtil.validateUserIdAndJwtToken(jwtFromHeader)) {
 					AuthorizationHeaderRequestWrapper authorizationHeaderRequestWrapper = new AuthorizationHeaderRequestWrapper(
-							request, "");
+							request, authHeader != null ? authHeader : "");
 					filterChain.doFilter(authorizationHeaderRequestWrapper, servletResponse);
 					return;
 				}


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

AMM-2343
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)

---

## ℹ️ Additional Information

fixed empty Authorization header.- due to this issue, lock unlock api was returning 500 - internal server error
